### PR TITLE
Fix errors when exec vbs and cmd files if %APPDATA% contains spaces (in the username)

### DIFF
--- a/HideGoXLR_startup.cmd
+++ b/HideGoXLR_startup.cmd
@@ -1,1 +1,1 @@
-PowerShell -NoProfile -Command "%APPDATA%\HideGoXLR.ps1" >> "%TEMP%\StartupLog.txt" 2>&1
+cd %APPDATA% && PowerShell -NoProfile -Command ".\HideGoXLR.ps1" >> "%TEMP%\StartupLog.txt" 2>&1

--- a/HideGoXLR_startup.vbs
+++ b/HideGoXLR_startup.vbs
@@ -1,1 +1,1 @@
-CreateObject("Wscript.Shell").Run "%APPDATA%\HideGoXLR_startup", 0, True
+CreateObject("Wscript.Shell").Run """%APPDATA%\HideGoXLR_startup""", 0, True


### PR DESCRIPTION
I had do adjust two files because of a space in my user name.

Did not find a better way to invoke the command in the cmd file... the usual tricks like & {"... ..."} did not work as it seems the space first hidden in the %APPDATA% variable is a bad combination...